### PR TITLE
fix: hide masterlist error message from user and show translated error string

### DIFF
--- a/src/views/Servers.vue
+++ b/src/views/Servers.vue
@@ -71,10 +71,10 @@ const filters = t("FILTERS");
 
 		<div class="table">
 			<div class="table__wrapper">
-				<div class="table__center" v-if="servers.serversLoading">
+				<div class="table__center" v-if="servers.isLoading">
 					<loader />
 				</div>
-				<div class="table__center" v-else-if="servers.serversError != null">
+				<div class="table__center" v-else-if="servers.isError">
 					<svg
 						width="24"
 						height="24"
@@ -88,9 +88,7 @@ const filters = t("FILTERS");
 						/>
 					</svg>
 					<div class="msg">
-						Ошибка загрузки списка серверов<template v-if="servers.serversError"
-							>:<br />{{ t(servers.serversError) }}</template
-						>
+						{{ t("MASTERLIST_RESPONSE_ERROR") }}
 					</div>
 				</div>
 				<servers-table v-else />

--- a/src/views/servers/ServersStat.vue
+++ b/src/views/servers/ServersStat.vue
@@ -3,7 +3,6 @@
 import {useServersStore} from "@/stores/servers";
 import {computed} from "vue";
 import {useLocalization} from "@/stores/localization";
-import Loader from "@/components/Loader.vue";
 
 const servers = useServersStore();
 const serversCount = computed(() => servers.servers.length);
@@ -12,8 +11,8 @@ const { tPlural: t } = useLocalization();
 </script>
 
 <template>
-    <h3 class="stat__servers">{{ t('SERVERS_ONLINE', servers.serversLoading ? '...' : serversCount) }}</h3>
-    <h3 class="stat__players">{{ t('PLAYERS_ONLINE', servers.serversLoading ? '...' : playersCount) }}</h3>
+    <h3 class="stat__servers">{{ t('SERVERS_ONLINE', servers.isLoading ? '...' : serversCount) }}</h3>
+    <h3 class="stat__players">{{ t('PLAYERS_ONLINE', servers.isLoading ? '...' : playersCount) }}</h3>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
Should resolve:  https://discord.com/channels/371265202378899476/371270983623114753/1218621615114293318

Instead it will just look like that:
![image](https://github.com/altmp/altv-ui/assets/51422045/04ca590d-b0cb-4ac0-8c8b-76dcd91bac0b)
