### PR TITLE
chore: fix all warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
 				"pinia": "2.2.6",
 				"rss-parser": "3.13.0",
 				"sanitize-html": "2.13.1",
-				"sass": "1.80.6",
-				"vite-plugin-singlefile": "2.0.3",
 				"vue": "3.5.12",
 				"vue-router": "4.4.5",
 				"vue-virtual-scroller": "2.0.0-beta.7"
@@ -23,8 +21,10 @@
 				"@vitejs/plugin-vue": "5.1.4",
 				"jsdom": "25.0.1",
 				"prettier": "3.3.3",
+				"sass": "1.80.6",
 				"typescript": "5.6.3",
 				"vite": "5.4.10",
+				"vite-plugin-singlefile": "2.0.3",
 				"vitest": "2.1.4",
 				"vue-tsc": "2.1.10"
 			}
@@ -89,6 +89,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -105,6 +106,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -121,6 +123,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -137,6 +140,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -153,6 +157,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -169,6 +174,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -185,6 +191,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -201,6 +208,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -217,6 +225,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -233,6 +242,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -249,6 +259,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -265,6 +276,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -281,6 +293,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -297,6 +310,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -313,6 +327,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -329,6 +344,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -345,6 +361,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -361,6 +378,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -377,6 +395,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -393,6 +412,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -409,6 +429,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -425,6 +446,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -441,6 +463,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -460,6 +483,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
 			"integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -499,6 +523,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -519,6 +544,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -539,6 +565,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -559,6 +586,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -579,6 +607,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -599,6 +628,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -619,6 +649,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -639,6 +670,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -659,6 +691,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -679,6 +712,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -699,6 +733,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -719,6 +754,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -739,6 +775,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -759,6 +796,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -772,6 +810,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -785,6 +824,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -798,6 +838,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -811,6 +852,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -824,6 +866,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -837,6 +880,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -850,6 +894,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -863,6 +908,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -876,6 +922,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -889,6 +936,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -902,6 +950,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -915,6 +964,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -928,6 +978,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -941,6 +992,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -954,6 +1006,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -967,6 +1020,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -980,6 +1034,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -990,13 +1045,14 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
 			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "22.9.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
 			"integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.19.8"
@@ -1380,6 +1436,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -1429,6 +1486,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
 			"integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"readdirp": "^4.0.1"
@@ -1551,6 +1609,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"bin": {
@@ -1631,6 +1690,7 @@
 			"version": "0.21.5",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
 			"integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -1701,6 +1761,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -1728,6 +1789,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -1825,12 +1887,14 @@
 			"version": "4.3.7",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
 			"integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"engines": {
@@ -1841,6 +1905,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1854,6 +1919,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -1936,6 +2002,7 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -2035,6 +2102,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true
 		},
@@ -2098,6 +2166,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -2216,6 +2285,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
 			"integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14.16.0"
@@ -2229,6 +2299,7 @@
 			"version": "4.24.4",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.4.tgz",
 			"integrity": "sha512-vGorVWIsWfX3xbcyAS+I047kFKapHYivmkaT63Smj77XwvLSJos6M1xGqZnBPFQFBRZDOcG1QnYEIxAvTr/HjA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.6"
@@ -2313,6 +2384,7 @@
 			"version": "1.80.6",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.80.6.tgz",
 			"integrity": "sha512-ccZgdHNiBF1NHBsWvacvT5rju3y1d/Eu+8Ex6c21nHp2lZGLBEtuwc415QfiI1PJa1TpCo3iXwwSRjRpn2Ckjg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^4.0.0",
@@ -2466,6 +2538,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -2518,13 +2591,14 @@
 			"version": "6.19.8",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
 			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vite": {
 			"version": "5.4.10",
 			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
 			"integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.21.3",
@@ -2606,6 +2680,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.0.3.tgz",
 			"integrity": "sha512-OEBEwdX8nCGPSdtaB1D7rryYnT+YfPTS8ojL1TDyeUF+bWDCTfRriQqw6T0vl9EbKI/KMg7szN3awst6cLrKkA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"micromatch": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
 		"pinia": "2.2.6",
 		"rss-parser": "3.13.0",
 		"sanitize-html": "2.13.1",
-		"sass": "1.80.6",
-		"vite-plugin-singlefile": "2.0.3",
 		"vue": "3.5.12",
 		"vue-router": "4.4.5",
 		"vue-virtual-scroller": "2.0.0-beta.7"
 	},
 	"devDependencies": {
+		"sass": "1.80.6",
+		"vite-plugin-singlefile": "2.0.3",
 		"@altv/types-webview": "16.2.1",
 		"@types/node": "22.9.0",
 		"@types/sanitize-html": "2.13.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -169,9 +169,6 @@ provide(
 </template>
 
 <style lang="scss">
-@import "@/assets/base.scss";
-@import "@/assets/_util.scss";
-
 #page {
 	height: 100vh;
 	background:
@@ -242,6 +239,7 @@ provide(
 				$width: 50%;
 				width: $width;
 				opacity: 0.15;
+				animation: indeterminate-progress-startup 1.5s infinite ease-in-out;
 
 				@keyframes indeterminate-progress-startup {
 					0% {
@@ -252,8 +250,6 @@ provide(
 						margin-left: 101%;
 					}
 				}
-
-				animation: indeterminate-progress-startup 1.5s infinite ease-in-out;
 			}
 		}
 	}

--- a/src/assets/base.scss
+++ b/src/assets/base.scss
@@ -1,5 +1,6 @@
-@import "util";
-@import "palette";
+@use "util" as *;
+@use "palette" as *;
+
 //noinspection CssUnknownTarget
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;700;800;900&display=swap");
 

--- a/src/components/AltButton.vue
+++ b/src/components/AltButton.vue
@@ -20,8 +20,6 @@ defineProps({
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_palette.scss";
-
 .button {
 	padding: 0 u(16);
 	display: flex;

--- a/src/components/LanguageFlag.vue
+++ b/src/components/LanguageFlag.vue
@@ -22,8 +22,6 @@ defineProps({
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 .lang {
 	display: flex;
 	align-items: center;

--- a/src/components/PlayerCount.vue
+++ b/src/components/PlayerCount.vue
@@ -14,9 +14,6 @@ defineProps({
 </template>
 
 <style scoped lang="scss">
-@import "@/assets/_palette.scss";
-@import "@/assets/_util.scss";
-
 p.player-count__online {
 	font-weight: 500; // 600 in figma
 	font-size: u(16);

--- a/src/components/ServerIcons.vue
+++ b/src/components/ServerIcons.vue
@@ -27,8 +27,6 @@ const { t } = useLocalization();
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 .server-icons {
 	display: flex;
 	gap: u(16);

--- a/src/components/VolumeDisplay.vue
+++ b/src/components/VolumeDisplay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineEmits, ref } from "vue";
+import { ref } from "vue";
 
 const props = defineProps<{ value: number; label: string }>();
 
@@ -18,8 +18,6 @@ const input = ref<HTMLInputElement | null>(null);
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 $thumbSize: 20;
 $thickness: 4;
 $margin: 16;

--- a/src/components/container/BlockContainer.vue
+++ b/src/components/container/BlockContainer.vue
@@ -18,8 +18,6 @@ const props = defineProps<{
 </template>
 
 <style scoped lang="scss">
-@import "@/assets/_util.scss";
-
 .frame {
 	background: rgba(241, 242, 242, 0.05);
 	width: 100%;

--- a/src/components/container/Tooltip.vue
+++ b/src/components/container/Tooltip.vue
@@ -16,8 +16,6 @@ const props = defineProps({
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_palette.scss";
-
 .tooltip-element {
 	position: relative;
 

--- a/src/components/form/AltCheckbox.vue
+++ b/src/components/form/AltCheckbox.vue
@@ -35,8 +35,6 @@ function onInput(event: Event) {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 .checkbox {
 	min-height: u(24);
 	display: flex;

--- a/src/components/form/AltDropdown.vue
+++ b/src/components/form/AltDropdown.vue
@@ -112,8 +112,6 @@ const current = computed(
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 .dropdown {
 	width: 100%;
 	height: u(50);

--- a/src/components/form/AltInput.vue
+++ b/src/components/form/AltInput.vue
@@ -37,8 +37,6 @@ defineExpose({ focus });
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 .wrapper {
 	position: relative;
 	width: 100%;

--- a/src/components/form/AltKeyInput.vue
+++ b/src/components/form/AltKeyInput.vue
@@ -71,8 +71,6 @@ function getKeyName(value: number) {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 div {
 	width: max-content;
 	height: u(50);

--- a/src/components/form/AltSlider.vue
+++ b/src/components/form/AltSlider.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineEmits, onMounted, ref, watch } from "vue";
+import { onMounted, ref, watch } from "vue";
 import {
 	playHoverSound,
 	playSliderEnterSound,
@@ -101,8 +101,6 @@ watch(
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 $thumbSize: 20;
 $thickness: 4;
 $margin: 16;

--- a/src/components/persist/Netgraph.vue
+++ b/src/components/persist/Netgraph.vue
@@ -7,29 +7,29 @@ const ui = useUIStore();
 <template>
 	<section>
 		<table class="netgraph">
-			<tr>
-				<td>FPS:</td>
-				<td>{{ ui.netgraph.fps }}</td>
-			</tr>
-			<tr>
-				<td>RTT:</td>
-				<td>{{ ui.netgraph.rtt }} ms</td>
-			</tr>
-			<tr>
-				<td>TX:</td>
-				<td>{{ (ui.netgraph.tx / 1024).toFixed(2) }} Kbps</td>
-			</tr>
-			<tr>
-				<td>RX:</td>
-				<td>{{ (ui.netgraph.rx / 1024).toFixed(2) }} Kbps</td>
-			</tr>
+			<tbody>
+				<tr>
+					<td>FPS:</td>
+					<td>{{ ui.netgraph.fps }}</td>
+				</tr>
+				<tr>
+					<td>RTT:</td>
+					<td>{{ ui.netgraph.rtt }} ms</td>
+				</tr>
+				<tr>
+					<td>TX:</td>
+					<td>{{ (ui.netgraph.tx / 1024).toFixed(2) }} Kbps</td>
+				</tr>
+				<tr>
+					<td>RX:</td>
+					<td>{{ (ui.netgraph.rx / 1024).toFixed(2) }} Kbps</td>
+				</tr>
+			</tbody>
 		</table>
 	</section>
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 .netgraph {
 	position: fixed;
 	left: u(40);

--- a/src/components/persist/SideNavigation.vue
+++ b/src/components/persist/SideNavigation.vue
@@ -243,9 +243,6 @@ function exit() {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 .navigation {
 	border-right: #f1f2f21a u(1) solid;
 	display: flex;

--- a/src/components/persist/console/Console.vue
+++ b/src/components/persist/console/Console.vue
@@ -214,8 +214,7 @@ const consoleActuallyTransparent = computed(
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
+@use "sass:color";
 
 .actions {
 	display: flex;
@@ -234,7 +233,7 @@ const consoleActuallyTransparent = computed(
 		justify-content: center;
 		align-items: center;
 		aspect-ratio: 1 / 1;
-		background: rgba(darken($back_black, 2), 1);
+		background: rgba(color.adjust($back_black, $lightness: -2%), 1);
 		border: solid u(1) rgba($text_light, 0.2);
 		border-radius: u(8);
 		fill: rgba(255, 255, 255, 0.8);
@@ -242,7 +241,7 @@ const consoleActuallyTransparent = computed(
 		cursor: pointer;
 
 		&[data-active="true"] {
-			background: rgba(lighten($back_black, 2), 1);
+			background: rgba(color.adjust($back_black, $lightness: 2%), 1);
 			border-color: rgba($text_light, 0.4);
 		}
 
@@ -301,7 +300,7 @@ const consoleActuallyTransparent = computed(
 .console {
 	height: 40vh;
 	width: 45vw;
-	background: rgba(darken($back_black, 2), 1);
+	background: rgba(color.adjust($back_black, $lightness: 2%), 1);
 	border: solid u(1) rgba($text_light, 0.2);
 	font-family: "Jetbrains Mono", monospace;
 	font-weight: 300;

--- a/src/components/persist/console/ConsoleEntry.vue
+++ b/src/components/persist/console/ConsoleEntry.vue
@@ -83,16 +83,19 @@ const formattedTime = useFormattedTime(computed(() => props.item.time));
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
+@use "sass:color";
 
 .message {
+	font-size: u(14);
+	border-top: solid u(1) rgba(white, 0.15);
+	box-sizing: border-box;
+	line-height: u(20);
 	padding: u(7) u(18) u(7) u(30);
 
 	&.error {
 		background: rgba(#eb2f06, 0.1);
-		color: lighten(#e55039, 10);
-		fill: lighten(#e55039, 10);
+		color: color.adjust(#e55039, $lightness: 10%);
+		fill: color.adjust(#e55039, $lightness: 10%);
 	}
 
 	&.warn {
@@ -103,14 +106,14 @@ const formattedTime = useFormattedTime(computed(() => props.item.time));
 
 	&.info {
 		background: rgba(#3498db, 0.1);
-		color: lighten(#3498db, 10);
-		fill: lighten(#3498db, 10);
+		color: color.adjust(#3498db, $lightness: 10%);
+		fill: color.adjust(#3498db, $lightness: 10%);
 	}
 
 	&.debug {
 		background: rgba(#9b59b6, 0.1);
-		color: lighten(#9b59b6, 20);
-		fill: lighten(#9b59b6, 20);
+		color: color.adjust(#9b59b6, $lightness: 20%);
+		fill: color.adjust(#9b59b6, $lightness: 20%);
 	}
 
 	svg {
@@ -129,6 +132,7 @@ const formattedTime = useFormattedTime(computed(() => props.item.time));
 		padding-bottom: u(10);
 		color: #b2bec3;
 		text-align: right;
+		overflow: hidden;
 
 		&,
 		* {
@@ -170,8 +174,6 @@ const formattedTime = useFormattedTime(computed(() => props.item.time));
 				fill: rgba(white, 0.85);
 			}
 		}
-
-		overflow: hidden;
 	}
 
 	.count {
@@ -201,10 +203,5 @@ const formattedTime = useFormattedTime(computed(() => props.item.time));
 	:deep(*) {
 		user-select: text;
 	}
-
-	font-size: u(14);
-	border-top: solid u(1) rgba(white, 0.15);
-	box-sizing: border-box;
-	line-height: u(20);
 }
 </style>

--- a/src/components/persist/console/ConsoleOutput.vue
+++ b/src/components/persist/console/ConsoleOutput.vue
@@ -74,9 +74,6 @@ const itemSize = Math.floor((window.innerHeight / 1080) * 35);
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 .console-output {
 	overflow: hidden;
 	display: flex;

--- a/src/components/persist/modals/ConnectModal.vue
+++ b/src/components/persist/modals/ConnectModal.vue
@@ -172,9 +172,6 @@ function connect() {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 .connect {
 	height: u(400);
 	min-width: u(720);

--- a/src/components/persist/modals/DeleteServerDataModal.vue
+++ b/src/components/persist/modals/DeleteServerDataModal.vue
@@ -65,8 +65,6 @@ function cancel() {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_palette.scss";
-
 .modal {
 	display: flex;
 	flex-direction: column;

--- a/src/components/persist/modals/DirectConnectModal.vue
+++ b/src/components/persist/modals/DirectConnectModal.vue
@@ -71,8 +71,6 @@ watch(
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_palette.scss";
-
 .direct-connect {
 	//min-width: u(500);
 	border-radius: u(8);

--- a/src/components/persist/modals/ExitModal.vue
+++ b/src/components/persist/modals/ExitModal.vue
@@ -44,8 +44,6 @@ function cancel() {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_palette.scss";
-
 .modal {
 	display: flex;
 	flex-direction: column;

--- a/src/components/persist/modals/Modals.vue
+++ b/src/components/persist/modals/Modals.vue
@@ -50,8 +50,6 @@ onUnmounted(() => document.removeEventListener("keyup", handler));
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_palette.scss";
-
 #close-modal {
 	position: fixed;
 	top: u(82);

--- a/src/components/persist/modals/NicknameModal.vue
+++ b/src/components/persist/modals/NicknameModal.vue
@@ -49,8 +49,6 @@ function save() {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_palette.scss";
-
 .modal {
 	display: flex;
 	flex-direction: column;

--- a/src/components/persist/modals/PermissionsModal.vue
+++ b/src/components/persist/modals/PermissionsModal.vue
@@ -85,8 +85,6 @@ function getPermissionName(id: number) {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_palette.scss";
-
 .modal {
 	display: flex;
 	flex-direction: column;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
 import { createPinia } from "pinia";
+import "@/assets/base.scss";
 
 import App from "./App.vue";
 import router from "./router";

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -183,9 +183,6 @@ const considerSupporting = sanitize(t("CONSIDER_SUPPORTING")).replace(
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 .view {
 	display: grid;
 	grid-template-columns: 1fr;

--- a/src/views/Connection.vue
+++ b/src/views/Connection.vue
@@ -140,8 +140,6 @@ watch(
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 .connection {
 	display: flex;
 	flex-direction: column;
@@ -213,6 +211,7 @@ watch(
 			&--bg {
 				$width: 50%;
 				width: $width;
+				animation: indeterminate-progress 1.5s infinite ease-in-out;
 
 				@keyframes indeterminate-progress {
 					0% {
@@ -222,8 +221,6 @@ watch(
 						margin-left: 101%;
 					}
 				}
-
-				animation: indeterminate-progress 1.5s infinite ease-in-out;
 			}
 
 			&--bg {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -131,9 +131,6 @@ function refreshMouseDown(e: MouseEvent) {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 .view {
 	display: grid;
 	grid-template-columns: 9fr 10fr;
@@ -162,9 +159,9 @@ function refreshMouseDown(e: MouseEvent) {
 	}
 
 	&__news {
-		@include scrollable-block(48);
 		width: 100%;
 		overflow: hidden;
+		@include scrollable-block(48);
 	}
 
 	&__header {

--- a/src/views/Servers.vue
+++ b/src/views/Servers.vue
@@ -98,9 +98,6 @@ const filters = t("FILTERS");
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_palette.scss";
-@import "@/assets/_util.scss";
-
 .view {
 	display: flex;
 	max-height: 100vh;
@@ -133,6 +130,7 @@ const filters = t("FILTERS");
 		display: none;
 		border-right: #f1f2f21a u(1) solid;
 		padding: u(10);
+		width: u(44);
 
 		[dir="rtl"] & {
 			border-right: none;
@@ -159,8 +157,6 @@ const filters = t("FILTERS");
 				transform: none;
 			}
 		}
-
-		width: u(44);
 	}
 
 	.menu {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -57,8 +57,6 @@ const { t } = useLocalization();
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 .view {
 	display: grid;
 	grid-template-columns: u(416) u(462) auto;

--- a/src/views/about/Developer.vue
+++ b/src/views/about/Developer.vue
@@ -66,9 +66,6 @@ onUnmounted(() => document.removeEventListener("mousemove", mousemoveGlobal));
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 .developer {
 	font-size: u(16);
 	white-space: pre-wrap;

--- a/src/views/home/HomeNews.vue
+++ b/src/views/home/HomeNews.vue
@@ -201,9 +201,6 @@ function openLink(link: string) {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 .news {
 	* {
 		unicode-bidi: unset !important;
@@ -251,20 +248,14 @@ function openLink(link: string) {
 		overflow: hidden;
 		word-break: break-word;
 
-		//[dir=rtl] & {
-		//    text-align: right;
-		//}
-
-		:deep {
-			img[data-emoji] {
-				min-width: 1.375em;
-				height: 1.375em;
-				font-weight: 500;
-				overflow: visible;
-				white-space: nowrap;
-				display: inline-block;
-				vertical-align: bottom;
-			}
+		:deep(img[data-emoji]) {
+			min-width: 1.375em;
+			height: 1.375em;
+			font-weight: 500;
+			overflow: visible;
+			white-space: nowrap;
+			display: inline-block;
+			vertical-align: bottom;
 		}
 	}
 
@@ -276,134 +267,132 @@ function openLink(link: string) {
 		font-weight: 500;
 		overflow: hidden;
 
-		:deep {
-			span[data-timestamp],
-			span[data-mention],
-			span[data-spoiler] {
+		:deep(span[data-timestamp]),
+		:deep(span[data-mention]),
+		:deep(span[data-spoiler]) {
+			display: none;
+		}
+
+		:deep(span[data-images]) {
+			width: 100%;
+			overflow: hidden;
+			overflow-x: scroll;
+			height: u(300);
+			display: flex;
+			gap: u(16);
+			margin-top: u(32);
+			padding-bottom: u(8);
+			box-sizing: content-box;
+			@include scrollbar();
+
+			img {
+				height: u(300);
+				width: auto;
+			}
+
+			&:empty {
 				display: none;
 			}
+		}
 
-			span[data-images] {
-				width: 100%;
-				overflow: hidden;
-				overflow-x: scroll;
-				height: u(300);
-				display: flex;
-				gap: u(16);
-				margin-top: u(32);
-				padding-bottom: u(8);
-				box-sizing: content-box;
-				@include scrollbar();
+		:deep(span.timestamp) {
+			background: rgba(white, 0.1);
+			border-radius: u(4);
+			padding: u(2);
+		}
 
-				img {
-					height: u(300);
-					width: auto;
-				}
+		:deep(span.mention) {
+			color: rgb(var(--color));
+			background: rgba(var(--color), 0.1);
+			border-radius: u(4);
+			font-weight: 600;
+			padding: u(2);
 
-				&:empty {
-					display: none;
-				}
+			&:hover {
+				background: rgba(var(--color), 0.3);
+			}
+		}
+
+		:deep(span.spoiler) {
+			background: #0c0c0c;
+			border-radius: u(4);
+			padding: u(2);
+			transition: background-color 0.1s ease;
+
+			> span {
+				opacity: 0;
+				transition: opacity 0.1s ease;
 			}
 
-			span.timestamp {
+			&.opened {
+				pointer-events: none;
 				background: rgba(white, 0.1);
-				border-radius: u(4);
-				padding: u(2);
-			}
-
-			span.mention {
-				color: rgb(var(--color));
-				background: rgba(var(--color), 0.1);
-				border-radius: u(4);
-				font-weight: 600;
-				padding: u(2);
-
-				&:hover {
-					background: rgba(var(--color), 0.3);
-				}
-			}
-
-			span.spoiler {
-				background: #0c0c0c;
-				border-radius: u(4);
-				padding: u(2);
-				transition: background-color 0.1s ease;
 
 				> span {
-					opacity: 0;
-					transition: opacity 0.1s ease;
-				}
-
-				&.opened {
-					pointer-events: none;
-					background: rgba(white, 0.1);
-
-					> span {
-						opacity: 1;
-					}
+					opacity: 1;
 				}
 			}
+		}
 
-			strong,
-			b {
-				font-weight: 700 !important;
-			}
+		:deep(strong),
+		:deep(b) {
+			font-weight: 700 !important;
+		}
 
-			blockquote {
-				padding: u(4) u(12);
-				margin: u(4) 0;
-				border-left: solid u(4) rgba(white, 0.3);
-				border-radius: u(2);
-			}
+		:deep(blockquote) {
+			padding: u(4) u(12);
+			margin: u(4) 0;
+			border-left: solid u(4) rgba(white, 0.3);
+			border-radius: u(2);
+		}
 
-			code {
-				margin: 0;
-				background: rgba(black, 0.3);
-				padding: u(2);
-				border-radius: u(4);
-				color: white;
-				font-weight: 300;
-				font-family: "JetBrains Mono", monospace;
-				line-height: u(20);
+		:deep(code) {
+			margin: 0;
+			background: rgba(black, 0.3);
+			padding: u(2);
+			border-radius: u(4);
+			color: white;
+			font-weight: 300;
+			font-family: "JetBrains Mono", monospace;
+			line-height: u(20);
 
-				.mention {
-					color: inherit;
-					background: unset;
-					border-radius: unset;
-					font-weight: 500;
-					padding: unset;
-				}
-			}
-
-			pre {
-				margin: 0;
-				padding: 0;
-
-				> code {
-					padding: u(12) u(8);
-					width: 100%;
-					display: block;
-					border: solid u(1) rgba(white, 0.1);
-				}
-			}
-
-			a {
-				color: $text_link;
+			.mention {
+				color: inherit;
+				background: unset;
+				border-radius: unset;
 				font-weight: 500;
+				padding: unset;
+			}
+		}
+
+		:deep(pre) {
+			margin: 0;
+			padding: 0;
+
+			> code {
+				padding: u(12) u(8);
+				width: 100%;
+				display: block;
+				border: solid u(1) rgba(white, 0.1);
+			}
+		}
+
+		:deep(a) {
+			color: $text_link;
+			font-weight: 500;
+		}
+
+		:deep(table) {
+			border-collapse: collapse;
+			td,
+			tr,
+			th {
+				border: solid u(1) rgba(white, 0.2);
+				padding: u(8);
 			}
 
-			table {
-				border-collapse: collapse;
-				td,
-				tr,
-				th {
-					border: solid u(1) rgba(white, 0.2);
-					padding: u(8);
-				}
-
-				th {
-					font-weight: 600;
-				}
+			th {
+				font-weight: 600;
 			}
 		}
 	}

--- a/src/views/home/HomeServer.vue
+++ b/src/views/home/HomeServer.vue
@@ -62,9 +62,6 @@ function open() {
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 .server {
 	&__name {
 		font-weight: 500;

--- a/src/views/home/HomeServerGroup.vue
+++ b/src/views/home/HomeServerGroup.vue
@@ -18,9 +18,6 @@ defineProps({
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 .servers {
 	display: flex;
 	flex-direction: column;

--- a/src/views/servers/ServersFilter.vue
+++ b/src/views/servers/ServersFilter.vue
@@ -83,9 +83,6 @@ const { t } = useLocalization();
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 h3 {
 	margin-bottom: u(16);
 }
@@ -94,9 +91,6 @@ h3 {
 	display: flex;
 	flex-direction: column;
 	gap: u(32);
-
-	&__group {
-	}
 
 	&__group-checkboxes {
 		display: flex;

--- a/src/views/servers/ServersTable.vue
+++ b/src/views/servers/ServersTable.vue
@@ -183,9 +183,6 @@ const tableData = computed(() => {
 </template>
 
 <style lang="scss">
-@import "@/assets/_util.scss";
-@import "@/assets/_palette.scss";
-
 table.servers-table {
 	width: 100%;
 	border-collapse: collapse;

--- a/src/views/settings/SettingsServerData.vue
+++ b/src/views/settings/SettingsServerData.vue
@@ -72,8 +72,6 @@ const { t } = useLocalization();
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/_util.scss";
-
 .server {
 	display: flex;
 	font-size: u(16);

--- a/src/views/settings/SettingsVoice.vue
+++ b/src/views/settings/SettingsVoice.vue
@@ -84,8 +84,6 @@ const { t } = useLocalization();
 </template>
 
 <style lang="scss" scoped>
-@import "@/assets/base.scss";
-
 h3 {
 	margin-bottom: u(16);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,8 +11,10 @@ export default defineConfig({
 	css: {
 		preprocessorOptions: {
 			scss: {
+				api: "modern-compiler",
 				additionalData: `
-          @import "@/assets/_util.scss";
+          @use "@/assets/_util.scss" as *;
+					@use "@/assets/_palette.scss" as *;
         `,
 			},
 		},


### PR DESCRIPTION
Silenced all warnings related to scss, deprecated `:deep` usage in vue, and removed unnecessary macro imports. Also moved all non-runtime dependencies to `devDependencies`

Before:

```bash
> build
> vue-tsc && vite build

vite v5.4.10 building for production...

...
LOTS OF WARNIGNG
...

✓ 503 modules transformed.
rendering chunks (1)...

Inlining: index-DHC-movS.js
Inlining: style-CQXQUMp-.css
dist/index.html  5,319.10 kB │ gzip: 3,198.54 kB
✓ built in 3.19s
```

After:

```bash
> build
> vue-tsc && vite build

vite v5.4.10 building for production...
✓ 504 modules transformed.
rendering chunks (1)...

Inlining: index-B-XvtPOZ.js
Inlining: style-CwjfhA1P.css
dist/index.html  3,902.08 kB │ gzip: 2,206.28 kB
✓ built in 3.02s
```

For some reason the bundle size reduces from 5.3MB to 3.9MB, even though I didn't remove anything, the ui was kept as it is. Also build time is improved slightly, but it's not that notable as project is small. Maybe some kind of polyfill was necessary for the deprecated features to work.. 